### PR TITLE
chore: use alpha branch of unirep-social dependence

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@unirep/circuits": "git+https://github.com/Unirep/circuits.git",
     "@unirep/crypto": "git+https://github.com/Unirep/crypto.git",
     "@unirep/unirep": "git+https://github.com/Unirep/unirep.git",
-    "@unirep/unirep-social": "git+https://github.com/Unirep/unirep-social.git",
+    "@unirep/unirep-social": "git+https://github.com/Unirep/unirep-social.git#alpha",
     "base64url": "^3.0.1",
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -629,7 +629,7 @@
     maci-crypto "^0.9.1"
     typescript "^4.4.2"
 
-"@unirep/unirep-social@git+https://github.com/Unirep/unirep-social.git":
+"@unirep/unirep-social@git+https://github.com/Unirep/unirep-social.git#alpha":
   version "1.0.0"
   resolved "git+https://github.com/Unirep/unirep-social.git#0f26f96523287de5e0955e4a502bd329577b2167"
   dependencies:


### PR DESCRIPTION
There's a fix for initializing the `unirepSocial` contract using a full provider in the `alpha` branch of unirep-social.