### PR TITLE
fix: empty epoch keys map

### DIFF
--- a/src/daemons/Synchronizer.ts
+++ b/src/daemons/Synchronizer.ts
@@ -1085,7 +1085,7 @@ export class Synchronizer extends EventEmitter {
         const epochTreeLeaves = [] as any[]
 
         // seal all epoch keys in current epoch
-        for (const epochKey of (this.epochKeyInEpoch[epoch] || {}).keys()) {
+        for (const epochKey of this.epochKeyInEpoch[epoch]?.keys() || []) {
             // this._checkEpochKeyRange(epochKey)
             // this._isEpochKeySealed(epochKey)
 


### PR DESCRIPTION
TIL `{}.keys()` isn't a function.